### PR TITLE
upgrade to hydra 6.2 and Rails 4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 4.0.0'
+gem 'rails', '~> 4.1.0'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.0'
@@ -27,7 +27,7 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 
-gem "hydra", "~> 6.1.0.rc8", "< 7.0.0"
+gem "hydra", "~> 6.2.0"
 
 gem "hydra-file_characterization", "~> 0.3.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/projecthydra/hydra-derivatives.git
-  revision: c94e1eb6acf0a978e672e84f60a2a3904b5e9866
+  revision: c5e620b74708488d8a3c4497b6915e30c7992667
   specs:
-    hydra-derivatives (0.0.8)
+    hydra-derivatives (0.1.0)
       active-fedora
       activesupport (>= 3.2.13, < 5.0)
       hydra-file_characterization
@@ -11,16 +11,20 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.0.5)
-      actionpack (= 4.0.5)
+    actionmailer (4.1.1)
+      actionpack (= 4.1.1)
+      actionview (= 4.1.1)
       mail (~> 2.5.4)
-    actionpack (4.0.5)
-      activesupport (= 4.0.5)
-      builder (~> 3.1.0)
-      erubis (~> 2.7.0)
+    actionpack (4.1.1)
+      actionview (= 4.1.1)
+      activesupport (= 4.1.1)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    active-fedora (6.7.6)
+    actionview (4.1.1)
+      activesupport (= 4.1.1)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+    active-fedora (6.7.7)
       activesupport (>= 3.0.0)
       deprecation
       mediashelf-loggable
@@ -29,26 +33,25 @@ GEM
       rdf (~> 1.1.1.1)
       rdf-rdfxml (= 1.0.1)
       rsolr
-      rubydora (~> 1.6, >= 1.6.5)
-    activemodel (4.0.5)
-      activesupport (= 4.0.5)
-      builder (~> 3.1.0)
-    activerecord (4.0.5)
-      activemodel (= 4.0.5)
-      activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.5)
-      arel (~> 4.0.0)
-    activerecord-deprecated_finders (1.0.3)
-    activesupport (4.0.5)
+      rubydora (~> 1.7.4)
+    activemodel (4.1.1)
+      activesupport (= 4.1.1)
+      builder (~> 3.1)
+    activerecord (4.1.1)
+      activemodel (= 4.1.1)
+      activesupport (= 4.1.1)
+      arel (~> 5.0.0)
+    activesupport (4.1.1)
       i18n (~> 0.6, >= 0.6.9)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
       thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
-    arel (4.0.2)
+      tzinfo (~> 1.1)
+    arel (5.0.1.20140414130214)
     bcrypt (3.1.7)
-    blacklight (4.5.0)
+    blacklight (4.7.0)
       bootstrap-sass (>= 2.2.0, < 2.4)
+      deprecation (~> 0.1)
       kaminari (~> 0.13)
       marc (>= 0.4.3, < 1.1)
       nokogiri (~> 1.6)
@@ -60,7 +63,7 @@ GEM
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     bootstrap_forms (4.0.1)
-    builder (3.1.4)
+    builder (3.2.2)
     cancan (1.6.10)
     capistrano (3.1.0)
       i18n
@@ -117,30 +120,30 @@ GEM
     hike (1.2.3)
     hooks (0.3.6)
       uber (~> 0.0.4)
-    hydra (6.1.0)
-      active-fedora (~> 6.7.0)
-      blacklight (~> 4.5.0)
-      hydra-head (~> 6.4.0)
+    hydra (6.2.0)
+      active-fedora (~> 6.7.7)
+      blacklight (~> 4.7.0)
+      hydra-head (~> 6.5.0)
       jettywrapper (~> 1.5.0)
       nokogiri (~> 1.6.0)
       nom-xml (~> 0.5.1)
       om (~> 3.0.3)
       rails (>= 3.2.15, < 5.0)
       rsolr (~> 1.0.9)
-      rubydora (~> 1.6.5)
+      rubydora (~> 1.7.4)
       solrizer (~> 3.1.0)
-    hydra-access-controls (6.4.2)
+    hydra-access-controls (6.5.2)
       active-fedora (~> 6.7)
       activesupport
-      blacklight (~> 4.0)
+      blacklight (~> 4.7)
       cancan
       deprecation
-    hydra-core (6.4.2)
-      active-fedora
-      blacklight (~> 4.0)
+    hydra-core (6.5.2)
+      active-fedora (~> 6.7)
+      blacklight (~> 4.7)
       block_helpers
       deprecation (>= 0.0.5)
-      hydra-access-controls (= 6.4.2)
+      hydra-access-controls (= 6.5.2)
       jettywrapper (>= 1.4.1)
       rails (>= 3.2.3, < 5)
     hydra-editor (0.2.2)
@@ -150,9 +153,9 @@ GEM
       rails (>= 3.2.13, < 5.0)
     hydra-file_characterization (0.3.1)
       activesupport (>= 3.0.0)
-    hydra-head (6.4.2)
-      hydra-access-controls (= 6.4.2)
-      hydra-core (= 6.4.2)
+    hydra-head (6.5.2)
+      hydra-access-controls (= 6.5.2)
+      hydra-core (= 6.5.2)
       rails (>= 3.2.6)
     i18n (0.6.9)
     jbuilder (1.5.3)
@@ -189,9 +192,9 @@ GEM
     mini_magick (3.7.0)
       subexec (~> 0.2.1)
     mini_portile (0.6.0)
-    minitest (4.7.5)
-    multi_json (1.10.0)
-    mysql2 (0.3.15)
+    minitest (5.3.4)
+    multi_json (1.10.1)
+    mysql2 (0.3.16)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
@@ -219,17 +222,19 @@ GEM
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rails (4.0.5)
-      actionmailer (= 4.0.5)
-      actionpack (= 4.0.5)
-      activerecord (= 4.0.5)
-      activesupport (= 4.0.5)
+    rails (4.1.1)
+      actionmailer (= 4.1.1)
+      actionpack (= 4.1.1)
+      actionview (= 4.1.1)
+      activemodel (= 4.1.1)
+      activerecord (= 4.1.1)
+      activesupport (= 4.1.1)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.0.5)
-      sprockets-rails (~> 2.0.0)
-    railties (4.0.5)
-      actionpack (= 4.0.5)
-      activesupport (= 4.0.5)
+      railties (= 4.1.1)
+      sprockets-rails (~> 2.0)
+    railties (4.1.1)
+      actionpack (= 4.1.1)
+      activesupport (= 4.1.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
@@ -259,7 +264,7 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    rubydora (1.6.5)
+    rubydora (1.7.4)
       activemodel
       activesupport
       deprecation
@@ -291,7 +296,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.0.1)
+    sprockets-rails (2.1.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
@@ -315,7 +320,8 @@ GEM
       polyglot (>= 0.3.1)
     turbolinks (2.2.2)
       coffee-rails
-    tzinfo (0.3.39)
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
     uber (0.0.6)
     uglifier (2.5.0)
       execjs (>= 0.3.0)
@@ -345,7 +351,7 @@ DEPENDENCIES
   devise-guests (~> 0.3)
   factory_girl_rails
   faker
-  hydra (~> 6.1.0.rc8, < 7.0.0)
+  hydra (~> 6.2.0)
   hydra-derivatives!
   hydra-editor
   hydra-file_characterization (~> 0.3.1)
@@ -358,7 +364,7 @@ DEPENDENCIES
   mysql2
   noid
   poltergeist
-  rails (~> 4.0.0)
+  rails (~> 4.1.0)
   rmagick
   rspec-rails
   rubyzip

--- a/app/views/layouts/lae.html.erb
+++ b/app/views/layouts/lae.html.erb
@@ -9,7 +9,6 @@
     <%= stylesheet_link_tag    "application" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
-    <%= raw(render_head_content) %>
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
@@ -26,7 +25,6 @@
   <div id="main-container" class="container">
             <!-- Top bar -->
             <div id="search-found" class="row hidden-phone">
-              <%= topbar_items.join('').html_safe %>
             </div>
             <!-- /Top bar -->
                   <div class="row">

--- a/app/views/shared/lae/index.html.erb
+++ b/app/views/shared/lae/index.html.erb
@@ -27,7 +27,7 @@
 
   <h2 class="hide-text"><%= t('blacklight.search.search_results') %></h2>
 
-  <%- if response_has_no_search_results? %>
+  <%- if @response.empty? %>
     <%= render "zero_results" %>
   <%- elsif render_grouped_response? %>
     <%= render_grouped_document_index %>


### PR DESCRIPTION
remove deprecation warnings. Helpers removed are stripped from blacklight 5.0. Interim step before upgrading to hydra 7.x. 
