### PR TITLE
Replace uniq! with uniq. Closes #258

### DIFF
--- a/lib/pul_store/lae/jhove_audit_utilities.rb
+++ b/lib/pul_store/lae/jhove_audit_utilities.rb
@@ -64,7 +64,7 @@ module PulStore
         end
         # Folder Exists?
         missing_folder = verify_folder_exists(audit_hash, opts)
-        missing_folder.uniq!{ |f| f[:folder_barcode] }.each do |f|
+        missing_folder.uniq{ |f| f[:folder_barcode] }.each do |f|
           errors << "Folder #{f[:folder_barcode]} does not exist"
         end
         # OCR w/ broken image || Image with broken ocr


### PR DESCRIPTION
i.e.

``` irb
Loading development environment (Rails 4.1.1)
irb(main):001:0>  [].uniq!.each { |u| puts u } #               <-- uniq!
NoMethodError: undefined method `each' for nil:NilClass
    from (irb):1
    from /home/jstroop/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands/console.rb:90:in `start'
    from /home/jstroop/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands/console.rb:9:in `start'
    from /home/jstroop/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands/commands_tasks.rb:69:in `console'
    from /home/jstroop/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
    from /home/jstroop/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.1/lib/rails/commands.rb:17:in `<top (required)>'
    from bin/rails:4:in `require'
    from bin/rails:4:in `<main>'
irb(main):002:0>  [].uniq.each { |u| puts u } #                <-- uniq
=> []
```
