### PR TITLE
Fixes issue with implicit conversion of pathname into string.

### DIFF
--- a/lib/tasks/install_fits.rb
+++ b/lib/tasks/install_fits.rb
@@ -15,7 +15,7 @@ open(PUL_STORE_CONFIG['fits_download'], 'rb') do |tmp|
       FileUtils.mkdir_p(File.dirname(fpath))
       zipfile.extract(e, fpath){ true }
     end
-    FileUtils.mv(unzip_root, final_dir)
-    File.chmod(0755, File.join(final_dir, 'fits.sh'))
+    FileUtils.mv(unzip_root.to_s, final_dir.to_s)
+    File.chmod(0755, File.join(final_dir.to_s, 'fits.sh'))
   end
 end


### PR DESCRIPTION
Not sure exactly what the issue is, but this seems common. I'm getting the error "no implicit conversion of Pathname into String" when running the fits rake task (ruby 2.1.2p95 & Rails 4.1.4). Easiest fix is to explicitly convert to string.

See: https://github.com/opbeat/opbeat_ruby/pull/4
